### PR TITLE
Remove `wasm` from github-actions' targets

### DIFF
--- a/.github/workflows/mean_bean_ci.yml
+++ b/.github/workflows/mean_bean_ci.yml
@@ -129,7 +129,7 @@ jobs:
         channel: [stable, beta, nightly]
         target:
           # WASM, off by default as most rust projects aren't compatible yet.
-          - wasm32-unknown-emscripten
+          # - wasm32-unknown-emscripten
           # Linux
           - aarch64-unknown-linux-gnu
           - aarch64-unknown-linux-musl


### PR DESCRIPTION
Remove `wasm-unknown-emscripten` from cross-compile tests' targets.